### PR TITLE
display LinkedIn API error response

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,10 @@ class SessionsController < ApplicationController
     def new
       redirect_url = "#{request.base_url}/auth/linkedin/callback"
       loc = get_code_location(redirect_url)
-      redirect_to loc["location"]
+      redirect_to loc["location"] and return if loc["location"]
+
+      flash[:errors] = "Something went wrong ~~ \nLinkedIn API status code: #{loc.code} ~~ \nLinkedIn API response message: #{loc.message}"
+      redirect_to :controller => 'pages', :action => 'index'
     end
   
     def create

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,35 @@
   </head>
 
   <body>
-<div class="bg-white">
-  <%= yield %>
+    <div>
+      <% if flash.any? %>
+        <% flash.each do |key, value| -%>
 
-</div>
+          <div class="rounded-md bg-yellow-50 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <!-- Heroicon name: solid/exclamation -->
+                <svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                </svg>
+              </div>
+              <div class="ml-3">
+                <h3 class="text-sm font-medium text-yellow-800">
+                  <%= key.capitalize %>
+                </h3>
+                <div class="mt-2 text-sm text-yellow-700">
+                  <p>
+                    <%= value.html_safe %>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end -%>
+      <% end %>
+  
+      <%= yield %>
+
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Responds to #4 

In an effort to improve error messaging transparency for users, this PR adds a display of the LinkedIn OAuth API status code and message if the flow is not successful. Hopefully, that will provide more context for users to diagnose what is wrong with their LinkedIn developer credentials flow.