### PR TITLE
update error response for failed callback

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,17 @@ class SessionsController < ApplicationController
     def new
       redirect_url = "#{request.base_url}/auth/linkedin/callback"
       loc = get_code_location(redirect_url)
+
       redirect_to loc["location"] and return if loc["location"]
 
-      flash[:errors] = "Something went wrong ~~ \nLinkedIn API status code: #{loc.code} ~~ \nLinkedIn API response message: #{loc.message}"
+      flash[:errors] = <<~HEREDOC
+        Something went wrong!
+        
+        LinkedIn Callback Error Response:
+
+        #{ActionView::Base.full_sanitizer.sanitize(loc.body).strip}
+      HEREDOC
+      
       redirect_to :controller => 'pages', :action => 'index'
     end
   


### PR DESCRIPTION
Based on feedback from #3 and closing #4 this updates the error response that is displayed during an unsuccessful callback attempt with LinkedIn. The new message is the actual error response LinkedIn provides. It should help users diagnose what went wrong in their credentialing process with LinkedIn.